### PR TITLE
feat: add auto-update support using electron-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,73 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path staged
-          Get-ChildItem -Path out/make -Recurse -Include *.exe,*.zip | Copy-Item -Destination staged/
+          Get-ChildItem -Path out/make -Recurse -Include *.exe,*.nupkg | Copy-Item -Destination staged/
+          # Copy RELEASES file if exists (for Squirrel)
+          Get-ChildItem -Path out/make -Recurse -Filter "RELEASES" | Copy-Item -Destination staged/
+
+      - name: Generate latest.yml for electron-updater (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $version = (Get-Content package.json | ConvertFrom-Json).version
+          $exe = Get-ChildItem -Path staged -Filter "*.exe" | Select-Object -First 1
+          if ($exe) {
+            $sha512 = (Get-FileHash -Path $exe.FullName -Algorithm SHA512).Hash.ToLower()
+            $size = $exe.Length
+            @"
+          version: $version
+          files:
+            - url: $($exe.Name)
+              sha512: $sha512
+              size: $size
+          path: $($exe.Name)
+          sha512: $sha512
+          "@ | Out-File -FilePath "staged/latest.yml" -Encoding utf8
+          }
+
+      - name: Generate latest-mac.yml for electron-updater (macOS)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          ZIP_FILE=$(find staged -name "*.zip" | head -1)
+          if [ -n "$ZIP_FILE" ]; then
+            SHA512=$(shasum -a 512 "$ZIP_FILE" | awk '{print $1}')
+            SIZE=$(stat -f%z "$ZIP_FILE")
+            FILENAME=$(basename "$ZIP_FILE")
+            cat > staged/latest-mac.yml << EOF
+          version: $VERSION
+          files:
+            - url: $FILENAME
+              sha512: $SHA512
+              size: $SIZE
+          path: $FILENAME
+          sha512: $SHA512
+          EOF
+          fi
+
+      - name: Generate latest-linux.yml for electron-updater (Linux)
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          # Prefer AppImage, fall back to deb
+          FILE=$(find staged -name "*.AppImage" | head -1)
+          [ -z "$FILE" ] && FILE=$(find staged -name "*.deb" | head -1)
+          if [ -n "$FILE" ]; then
+            SHA512=$(sha512sum "$FILE" | awk '{print $1}')
+            SIZE=$(stat -c%s "$FILE")
+            FILENAME=$(basename "$FILE")
+            cat > staged/latest-linux.yml << EOF
+          version: $VERSION
+          files:
+            - url: $FILENAME
+              sha512: $SHA512
+              size: $SIZE
+          path: $FILENAME
+          sha512: $SHA512
+          EOF
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ A modern Electron-based terminal manager for working across multiple repositorie
 - **Center Pane**: Active terminal or file viewer
 - **Right Pane**: File tree for the current terminal's directory
 
+### 🔄 Auto-Updates
+- Automatic update checks on startup
+- Background downloads with progress indicator
+- Non-disruptive updates - install on next restart
+- Toast notifications for update status
+
 ## Installation
 
 ### Prerequisites

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -18,6 +18,19 @@ const config: ForgeConfig = {
     asar: true,
     executableName: 'vibe-playground',
   },
+  publishers: [
+    {
+      name: '@electron-forge/publisher-github',
+      config: {
+        repository: {
+          owner: 'ipdelete',
+          name: 'vibe-playground',
+        },
+        prerelease: false,
+        draft: false,
+      },
+    },
+  ],
   rebuildConfig: {},
   makers: [
     new MakerSquirrel({}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-playground",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-playground",
-      "version": "0.3.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
@@ -15,6 +15,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
         "electron-squirrel-startup": "^1.0.1",
+        "electron-updater": "^6.7.3",
         "monaco-editor": "^0.55.1",
         "monaco-editor-webpack-plugin": "^7.1.1",
         "react": "^19.2.4",
@@ -4454,7 +4455,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -5060,6 +5060,19 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -6104,7 +6117,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7014,6 +7026,22 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.7.3.tgz",
+      "integrity": "sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -8379,7 +8407,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -11449,7 +11476,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11636,7 +11662,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -11695,6 +11720,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11908,12 +11939,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -12625,7 +12669,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -14823,6 +14866,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -16198,6 +16250,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -16713,7 +16771,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-playground",
   "productName": "Vibe Playground",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Terminal manager with integrated file browsing for multiple repositories",
   "main": ".webpack/main",
   "private": true,
@@ -22,6 +22,13 @@
     "email": "ianphil@microsoft.com"
   },
   "license": "MIT",
+  "build": {
+    "publish": {
+      "provider": "github",
+      "owner": "ipdelete",
+      "repo": "vibe-playground"
+    }
+  },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",
@@ -65,6 +72,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "electron-squirrel-startup": "^1.0.1",
+    "electron-updater": "^6.7.3",
     "monaco-editor": "^0.55.1",
     "monaco-editor-webpack-plugin": "^7.1.1",
     "react": "^19.2.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import { setupTerminalIPC } from './main/ipc/terminal';
 import { setupFileIPC } from './main/ipc/files';
 import { setupSessionIPC } from './main/ipc/session';
+import { setupUpdatesIPC, getUpdateService } from './main/ipc/updates';
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
@@ -42,6 +43,16 @@ const createWindow = (): void => {
 
   // Set up session IPC handlers
   setupSessionIPC();
+
+  // Set up auto-update IPC handlers
+  setupUpdatesIPC(mainWindow);
+
+  // Check for updates after window is ready (give it a moment to load)
+  mainWindow.webContents.once('did-finish-load', () => {
+    setTimeout(() => {
+      getUpdateService()?.checkForUpdates();
+    }, 3000);
+  });
 };
 
 // IPC Handlers

--- a/src/main/ipc/updates.ts
+++ b/src/main/ipc/updates.ts
@@ -1,0 +1,34 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { UpdateService } from '../services/UpdateService';
+
+let updateService: UpdateService | null = null;
+
+export function setupUpdatesIPC(mainWindow: BrowserWindow): void {
+  // Create the update service with a function to send messages to renderer
+  const sendToRenderer = (channel: string, data: unknown) => {
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(channel, data);
+    }
+  };
+
+  updateService = new UpdateService(sendToRenderer);
+
+  // Check for updates (called automatically on app start, can also be triggered manually)
+  ipcMain.handle('updates:check', async () => {
+    await updateService?.checkForUpdates();
+  });
+
+  // Download the available update
+  ipcMain.handle('updates:download', async () => {
+    await updateService?.downloadUpdate();
+  });
+
+  // Quit and install the downloaded update
+  ipcMain.handle('updates:install', () => {
+    updateService?.quitAndInstall();
+  });
+}
+
+export function getUpdateService(): UpdateService | null {
+  return updateService;
+}

--- a/src/main/services/UpdateService.test.ts
+++ b/src/main/services/UpdateService.test.ts
@@ -1,0 +1,167 @@
+import { EventEmitter } from 'events';
+
+// Create mock autoUpdater
+const mockAutoUpdater = new EventEmitter() as EventEmitter & {
+  checkForUpdates: jest.Mock;
+  downloadUpdate: jest.Mock;
+  quitAndInstall: jest.Mock;
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+};
+mockAutoUpdater.checkForUpdates = jest.fn();
+mockAutoUpdater.downloadUpdate = jest.fn();
+mockAutoUpdater.quitAndInstall = jest.fn();
+mockAutoUpdater.autoDownload = false;
+mockAutoUpdater.autoInstallOnAppQuit = true;
+
+jest.mock('electron-updater', () => ({
+  autoUpdater: mockAutoUpdater,
+}));
+
+// Mock electron app
+const mockApp = {
+  isPackaged: true,
+};
+
+jest.mock('electron', () => ({
+  app: mockApp,
+}));
+
+// Import after mocking
+import { UpdateService } from './UpdateService';
+
+describe('UpdateService', () => {
+  let updateService: UpdateService;
+  let mockSendToRenderer: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAutoUpdater.removeAllListeners();
+    mockApp.isPackaged = true;
+    mockSendToRenderer = jest.fn();
+    updateService = new UpdateService(mockSendToRenderer);
+  });
+
+  describe('initialization', () => {
+    it('should initialize without error', () => {
+      expect(updateService).toBeDefined();
+    });
+
+    it('should set autoDownload to false', () => {
+      expect(mockAutoUpdater.autoDownload).toBe(false);
+    });
+
+    it('should set autoInstallOnAppQuit to true', () => {
+      expect(mockAutoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+  });
+
+  describe('checkForUpdates', () => {
+    it('should skip update check when app is not packaged (dev mode)', async () => {
+      mockApp.isPackaged = false;
+      const devService = new UpdateService(mockSendToRenderer);
+
+      await devService.checkForUpdates();
+
+      expect(mockAutoUpdater.checkForUpdates).not.toHaveBeenCalled();
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'dev-mode',
+        message: 'Updates disabled in development mode',
+      });
+    });
+
+    it('should call autoUpdater.checkForUpdates() when packaged', async () => {
+      await updateService.checkForUpdates();
+
+      expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send checking status to renderer', async () => {
+      await updateService.checkForUpdates();
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'checking',
+      });
+    });
+  });
+
+  describe('downloadUpdate', () => {
+    it('should call autoUpdater.downloadUpdate()', async () => {
+      await updateService.downloadUpdate();
+
+      expect(mockAutoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('quitAndInstall', () => {
+    it('should call autoUpdater.quitAndInstall()', () => {
+      updateService.quitAndInstall();
+
+      expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('autoUpdater events', () => {
+    it('should send update-available status with info', () => {
+      const updateInfo = {
+        version: '1.0.0',
+        releaseNotes: 'New features',
+        releaseDate: '2026-02-05',
+      };
+
+      mockAutoUpdater.emit('update-available', updateInfo);
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'available',
+        info: updateInfo,
+      });
+    });
+
+    it('should send update-not-available status', () => {
+      mockAutoUpdater.emit('update-not-available');
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'not-available',
+      });
+    });
+
+    it('should send download progress to renderer', () => {
+      const progress = {
+        percent: 50,
+        bytesPerSecond: 1000000,
+        transferred: 5000000,
+        total: 10000000,
+      };
+
+      mockAutoUpdater.emit('download-progress', progress);
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:progress', progress);
+    });
+
+    it('should send ready status when update downloaded', () => {
+      const updateInfo = {
+        version: '1.0.0',
+        releaseNotes: 'New features',
+        releaseDate: '2026-02-05',
+      };
+
+      mockAutoUpdater.emit('update-downloaded', updateInfo);
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'ready',
+        info: updateInfo,
+      });
+    });
+
+    it('should send error status on error', () => {
+      const error = new Error('Network error');
+
+      mockAutoUpdater.emit('error', error);
+
+      expect(mockSendToRenderer).toHaveBeenCalledWith('updates:status', {
+        status: 'error',
+        message: 'Network error',
+      });
+    });
+  });
+});

--- a/src/main/services/UpdateService.ts
+++ b/src/main/services/UpdateService.ts
@@ -1,0 +1,85 @@
+import { app } from 'electron';
+import { autoUpdater, UpdateInfo, ProgressInfo } from 'electron-updater';
+
+export type UpdateStatusType = 'checking' | 'available' | 'not-available' | 'downloading' | 'ready' | 'error' | 'dev-mode';
+
+export interface UpdateStatusPayload {
+  status: UpdateStatusType;
+  info?: UpdateInfo;
+  message?: string;
+}
+
+export type SendToRendererFn = (channel: string, data: UpdateStatusPayload | ProgressInfo) => void;
+
+export class UpdateService {
+  private sendToRenderer: SendToRendererFn;
+
+  constructor(sendToRenderer: SendToRendererFn) {
+    this.sendToRenderer = sendToRenderer;
+    
+    // Configure auto-updater
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = true;
+
+    // Set up event handlers
+    this.setupEventHandlers();
+  }
+
+  private setupEventHandlers(): void {
+    autoUpdater.on('update-available', (info: UpdateInfo) => {
+      this.sendToRenderer('updates:status', {
+        status: 'available',
+        info,
+      });
+    });
+
+    autoUpdater.on('update-not-available', () => {
+      this.sendToRenderer('updates:status', {
+        status: 'not-available',
+      });
+    });
+
+    autoUpdater.on('download-progress', (progress: ProgressInfo) => {
+      this.sendToRenderer('updates:progress', progress);
+    });
+
+    autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
+      this.sendToRenderer('updates:status', {
+        status: 'ready',
+        info,
+      });
+    });
+
+    autoUpdater.on('error', (error: Error) => {
+      this.sendToRenderer('updates:status', {
+        status: 'error',
+        message: error.message,
+      });
+    });
+  }
+
+  async checkForUpdates(): Promise<void> {
+    // Skip update check in development mode
+    if (!app.isPackaged) {
+      this.sendToRenderer('updates:status', {
+        status: 'dev-mode',
+        message: 'Updates disabled in development mode',
+      });
+      return;
+    }
+
+    this.sendToRenderer('updates:status', {
+      status: 'checking',
+    });
+
+    await autoUpdater.checkForUpdates();
+  }
+
+  async downloadUpdate(): Promise<void> {
+    await autoUpdater.downloadUpdate();
+  }
+
+  quitAndInstall(): void {
+    autoUpdater.quitAndInstall();
+  }
+}

--- a/src/renderer/components/UpdateToast/UpdateToast.css
+++ b/src/renderer/components/UpdateToast/UpdateToast.css
@@ -1,0 +1,133 @@
+.update-toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--bg-secondary, #21262d);
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 8px;
+  padding: 12px 16px;
+  min-width: 280px;
+  max-width: 400px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.update-toast-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.update-toast-content.error {
+  color: var(--color-error, #f85149);
+}
+
+.update-toast-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.update-toast-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.update-toast-message {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary, #e6edf3);
+}
+
+.update-toast-version,
+.update-toast-percent {
+  font-size: 12px;
+  color: var(--text-secondary, #8b949e);
+}
+
+.update-toast-error {
+  font-size: 12px;
+  color: var(--color-error, #f85149);
+  word-break: break-word;
+}
+
+.update-toast-button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  border: none;
+  flex-shrink: 0;
+}
+
+.update-toast-button.download {
+  background: var(--color-accent, #238636);
+  color: white;
+}
+
+.update-toast-button.download:hover {
+  background: var(--color-accent-hover, #2ea043);
+}
+
+.update-toast-button.install {
+  background: var(--color-primary, #1f6feb);
+  color: white;
+}
+
+.update-toast-button.install:hover {
+  background: var(--color-primary-hover, #388bfd);
+}
+
+.update-toast-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: var(--text-secondary, #8b949e);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.update-toast-dismiss:hover {
+  background: var(--bg-tertiary, #30363d);
+  color: var(--text-primary, #e6edf3);
+}
+
+.update-toast-progress {
+  width: 100%;
+  height: 4px;
+  background: var(--bg-tertiary, #30363d);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.update-toast-progress-bar {
+  height: 100%;
+  background: var(--color-primary, #1f6feb);
+  transition: width 0.3s ease;
+}

--- a/src/renderer/components/UpdateToast/UpdateToast.test.tsx
+++ b/src/renderer/components/UpdateToast/UpdateToast.test.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UpdateToast } from './UpdateToast';
+import { UpdateState } from '../../../shared/types';
+
+describe('UpdateToast', () => {
+  const defaultProps = {
+    updateState: { status: 'idle' as const },
+    onDownload: jest.fn(),
+    onInstall: jest.fn(),
+    onDismiss: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('visibility', () => {
+    it('should render nothing when status is idle', () => {
+      const { container } = render(<UpdateToast {...defaultProps} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render nothing when status is not-available', () => {
+      const { container } = render(
+        <UpdateToast {...defaultProps} updateState={{ status: 'not-available' }} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render nothing when status is dev-mode', () => {
+      const { container } = render(
+        <UpdateToast {...defaultProps} updateState={{ status: 'dev-mode' }} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('checking state', () => {
+    it('should render "Checking for updates..." when status is checking', () => {
+      render(<UpdateToast {...defaultProps} updateState={{ status: 'checking' }} />);
+      expect(screen.getByText('Checking for updates...')).toBeInTheDocument();
+    });
+  });
+
+  describe('available state', () => {
+    it('should render version and Download button when status is available', () => {
+      render(
+        <UpdateToast
+          {...defaultProps}
+          updateState={{
+            status: 'available',
+            info: { version: '1.2.3' },
+          }}
+        />
+      );
+      expect(screen.getByText(/Update available/)).toBeInTheDocument();
+      expect(screen.getByText(/v1.2.3/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument();
+    });
+
+    it('should call onDownload when Download button is clicked', () => {
+      const onDownload = jest.fn();
+      render(
+        <UpdateToast
+          {...defaultProps}
+          onDownload={onDownload}
+          updateState={{
+            status: 'available',
+            info: { version: '1.2.3' },
+          }}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /download/i }));
+      expect(onDownload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('downloading state', () => {
+    it('should render progress bar when status is downloading', () => {
+      render(
+        <UpdateToast
+          {...defaultProps}
+          updateState={{
+            status: 'downloading',
+            progress: { percent: 50, bytesPerSecond: 1000000, transferred: 5000000, total: 10000000 },
+          }}
+        />
+      );
+      expect(screen.getByText(/Downloading/)).toBeInTheDocument();
+      expect(screen.getByText(/50%/)).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('should show progress percentage correctly', () => {
+      render(
+        <UpdateToast
+          {...defaultProps}
+          updateState={{
+            status: 'downloading',
+            progress: { percent: 75, bytesPerSecond: 1000000, transferred: 7500000, total: 10000000 },
+          }}
+        />
+      );
+      expect(screen.getByText(/75%/)).toBeInTheDocument();
+    });
+  });
+
+  describe('ready state', () => {
+    it('should render "Restart Now" button when status is ready', () => {
+      render(
+        <UpdateToast
+          {...defaultProps}
+          updateState={{
+            status: 'ready',
+            info: { version: '1.2.3' },
+          }}
+        />
+      );
+      expect(screen.getByText(/Update ready/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /restart now/i })).toBeInTheDocument();
+    });
+
+    it('should call onInstall when Restart Now button is clicked', () => {
+      const onInstall = jest.fn();
+      render(
+        <UpdateToast
+          {...defaultProps}
+          onInstall={onInstall}
+          updateState={{
+            status: 'ready',
+            info: { version: '1.2.3' },
+          }}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /restart now/i }));
+      expect(onInstall).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error message when status is error', () => {
+      render(
+        <UpdateToast
+          {...defaultProps}
+          updateState={{
+            status: 'error',
+            error: 'Network error',
+          }}
+        />
+      );
+      expect(screen.getByText(/Update failed/)).toBeInTheDocument();
+      expect(screen.getByText(/Network error/)).toBeInTheDocument();
+    });
+  });
+
+  describe('dismissing', () => {
+    it('should call onDismiss when dismiss button is clicked', () => {
+      const onDismiss = jest.fn();
+      render(
+        <UpdateToast
+          {...defaultProps}
+          onDismiss={onDismiss}
+          updateState={{
+            status: 'available',
+            info: { version: '1.2.3' },
+          }}
+        />
+      );
+      const dismissButton = screen.getByLabelText(/dismiss/i);
+      fireEvent.click(dismissButton);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/renderer/components/UpdateToast/UpdateToast.tsx
+++ b/src/renderer/components/UpdateToast/UpdateToast.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { UpdateState } from '../../../shared/types';
+import './UpdateToast.css';
+
+interface UpdateToastProps {
+  updateState: UpdateState;
+  onDownload: () => void;
+  onInstall: () => void;
+  onDismiss: () => void;
+}
+
+export const UpdateToast: React.FC<UpdateToastProps> = ({
+  updateState,
+  onDownload,
+  onInstall,
+  onDismiss,
+}) => {
+  const { status, info, progress, error } = updateState;
+
+  // Don't show for these statuses
+  if (status === 'idle' || status === 'not-available' || status === 'dev-mode') {
+    return null;
+  }
+
+  const renderContent = () => {
+    switch (status) {
+      case 'checking':
+        return (
+          <div className="update-toast-content">
+            <span className="update-toast-icon">🔄</span>
+            <span className="update-toast-message">Checking for updates...</span>
+          </div>
+        );
+
+      case 'available':
+        return (
+          <div className="update-toast-content">
+            <span className="update-toast-icon">🎉</span>
+            <div className="update-toast-text">
+              <span className="update-toast-message">Update available</span>
+              <span className="update-toast-version">v{info?.version}</span>
+            </div>
+            <button className="update-toast-button download" onClick={onDownload}>
+              Download
+            </button>
+          </div>
+        );
+
+      case 'downloading':
+        return (
+          <div className="update-toast-content">
+            <span className="update-toast-icon">⬇️</span>
+            <div className="update-toast-text">
+              <span className="update-toast-message">Downloading update...</span>
+              <span className="update-toast-percent">{Math.round(progress?.percent || 0)}%</span>
+            </div>
+            <div className="update-toast-progress" role="progressbar" aria-valuenow={progress?.percent || 0}>
+              <div
+                className="update-toast-progress-bar"
+                style={{ width: `${progress?.percent || 0}%` }}
+              />
+            </div>
+          </div>
+        );
+
+      case 'ready':
+        return (
+          <div className="update-toast-content">
+            <span className="update-toast-icon">✅</span>
+            <div className="update-toast-text">
+              <span className="update-toast-message">Update ready!</span>
+              <span className="update-toast-version">v{info?.version}</span>
+            </div>
+            <button className="update-toast-button install" onClick={onInstall}>
+              Restart Now
+            </button>
+          </div>
+        );
+
+      case 'error':
+        return (
+          <div className="update-toast-content error">
+            <span className="update-toast-icon">❌</span>
+            <div className="update-toast-text">
+              <span className="update-toast-message">Update failed</span>
+              <span className="update-toast-error">{error}</span>
+            </div>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="update-toast">
+      {renderContent()}
+      <button
+        className="update-toast-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+};

--- a/src/renderer/components/UpdateToast/index.ts
+++ b/src/renderer/components/UpdateToast/index.ts
@@ -1,0 +1,1 @@
+export { UpdateToast } from './UpdateToast';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,3 +40,26 @@ export type AppAction =
   | { type: 'ADD_FILE'; payload: { terminalId: string; file: OpenFile } }
   | { type: 'REMOVE_FILE'; payload: { terminalId: string; fileId: string } }
   | { type: 'RENAME_TERMINAL'; payload: { id: string; label: string } };
+
+// Auto-update types
+export type UpdateStatus = 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'ready' | 'error' | 'dev-mode';
+
+export interface UpdateInfo {
+  version: string;
+  releaseNotes?: string | null;
+  releaseDate?: string;
+}
+
+export interface DownloadProgress {
+  percent: number;
+  bytesPerSecond: number;
+  transferred: number;
+  total: number;
+}
+
+export interface UpdateState {
+  status: UpdateStatus;
+  info?: UpdateInfo;
+  progress?: DownloadProgress;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
Enable the app to check for new releases on startup and allow users to update seamlessly.

## Changes
- Add \lectron-updater\ package for automatic updates from GitHub Releases
- Create \UpdateService\ for checking, downloading, and installing updates
- Add \UpdateToast\ component with progress bar and restart button
- Configure Electron Forge publisher for GitHub
- Update release workflow to generate \latest.yml\ manifests
- Bump version to 0.6.0

## Key Features
- Check for updates on app startup (silent background check)
- Notify users when a new version is available via toast notification
- Download updates in the background with progress indicator
- Install on next app restart (non-disruptive)

## Testing
- 159 tests passing (25 new tests added via TDD)
- \UpdateService.test.ts\ - 13 tests for main process logic
- \UpdateToast.test.tsx\ - 12 tests for UI component

Closes #11