### PR TITLE
feat: Add git status indicators to file tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-playground",
   "productName": "Vibe Playground",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Terminal manager with integrated file browsing for multiple repositories",
   "main": ".webpack/main",
   "private": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import { setupAgentIPC } from './main/ipc/agent';
 import { setupFileIPC } from './main/ipc/files';
+import { setupGitIPC } from './main/ipc/git';
 import { setupSessionIPC } from './main/ipc/session';
 import { setupUpdatesIPC, getUpdateService } from './main/ipc/updates';
 
@@ -40,6 +41,9 @@ const createWindow = (): void => {
   
   // Set up file system IPC handlers
   setupFileIPC();
+
+  // Set up git IPC handlers
+  setupGitIPC();
 
   // Set up session IPC handlers
   setupSessionIPC();

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -1,0 +1,33 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { gitService, GitStatusMap } from '../services/GitService';
+import { fileWatcherService, GitStatusChangeEvent } from '../services/FileWatcherService';
+
+export function setupGitIPC(): void {
+  ipcMain.handle('git:isRepo', async (_event, dirPath: string): Promise<boolean> => {
+    return gitService.isGitRepository(dirPath);
+  });
+
+  ipcMain.handle('git:getStatus', async (_event, dirPath: string): Promise<GitStatusMap> => {
+    return gitService.getGitStatus(dirPath);
+  });
+
+  ipcMain.handle('git:getRoot', async (_event, dirPath: string): Promise<string | null> => {
+    return gitService.getGitRoot(dirPath);
+  });
+
+  ipcMain.handle('git:watchRepo', async (_event, repoRoot: string): Promise<boolean> => {
+    return fileWatcherService.watchGitRepo(repoRoot);
+  });
+
+  ipcMain.handle('git:unwatchRepo', async (_event, repoRoot: string): Promise<void> => {
+    fileWatcherService.unwatchGitRepo(repoRoot);
+  });
+
+  // Set up event forwarding to renderer for git status changes
+  fileWatcherService.onGitStatusChanged((event: GitStatusChangeEvent) => {
+    const windows = BrowserWindow.getAllWindows();
+    for (const window of windows) {
+      fileWatcherService.sendGitStatusToWindow(window, event);
+    }
+  });
+}

--- a/src/main/services/GitService.test.ts
+++ b/src/main/services/GitService.test.ts
@@ -1,0 +1,227 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+// Mock child_process
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+import { gitService, GitStatusMap } from './GitService';
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+// Helper to create platform-appropriate paths for test assertions
+const testPath = (...parts: string[]) => path.join(...parts);
+
+// Helper to create mock process
+function createMockProcess(stdout: string, stderr: string = '', exitCode: number = 0) {
+  const stdoutCallbacks: ((data: Buffer) => void)[] = [];
+  const stderrCallbacks: ((data: Buffer) => void)[] = [];
+  const closeCallbacks: ((code: number) => void)[] = [];
+  const errorCallbacks: ((err: Error) => void)[] = [];
+
+  const mockProc = {
+    stdout: {
+      on: jest.fn((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') stdoutCallbacks.push(cb);
+      }),
+    },
+    stderr: {
+      on: jest.fn((event: string, cb: (data: Buffer) => void) => {
+        if (event === 'data') stderrCallbacks.push(cb);
+      }),
+    },
+    on: jest.fn((event: string, cb: any) => {
+      if (event === 'close') closeCallbacks.push(cb);
+      if (event === 'error') errorCallbacks.push(cb);
+    }),
+  };
+
+  // Trigger callbacks after creation
+  setTimeout(() => {
+    if (stdout) {
+      stdoutCallbacks.forEach(cb => cb(Buffer.from(stdout)));
+    }
+    if (stderr) {
+      stderrCallbacks.forEach(cb => cb(Buffer.from(stderr)));
+    }
+    closeCallbacks.forEach(cb => cb(exitCode));
+  }, 0);
+
+  return mockProc;
+}
+
+describe('GitService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isGitRepository', () => {
+    it('should return true for a git repository', async () => {
+      mockSpawn.mockReturnValue(createMockProcess('.git') as any);
+
+      const result = await gitService.isGitRepository('/test/repo');
+
+      expect(result).toBe(true);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--git-dir'],
+        expect.objectContaining({ cwd: '/test/repo' })
+      );
+    });
+
+    it('should return false for a non-git directory', async () => {
+      mockSpawn.mockReturnValue(createMockProcess('', 'fatal: not a git repository', 128) as any);
+
+      const result = await gitService.isGitRepository('/test/not-a-repo');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getGitRoot', () => {
+    it('should return the repository root path', async () => {
+      const repoRoot = testPath('/home/user/repo');
+      mockSpawn.mockReturnValue(createMockProcess(repoRoot + '\n') as any);
+
+      const result = await gitService.getGitRoot(testPath('/home/user/repo/src'));
+
+      expect(result).toBe(repoRoot);
+    });
+
+    it('should return null for non-git directory', async () => {
+      mockSpawn.mockReturnValue(createMockProcess('', 'fatal: not a git repository', 128) as any);
+
+      const result = await gitService.getGitRoot('/tmp/random');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getGitStatus', () => {
+    const repoRoot = testPath('/repo');
+
+    it('should parse modified files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess(' M src/file.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/file.ts')]).toBe('modified');
+    });
+
+    it('should parse staged files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('M  src/staged.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/staged.ts')]).toBe('staged');
+    });
+
+    it('should parse added files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('A  src/new.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/new.ts')]).toBe('added');
+    });
+
+    it('should parse untracked files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('?? src/untracked.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/untracked.ts')]).toBe('untracked');
+    });
+
+    it('should parse deleted files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess(' D src/deleted.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/deleted.ts')]).toBe('deleted');
+    });
+
+    it('should parse renamed files correctly', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('R  old.ts -> new.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'new.ts')]).toBe('renamed');
+    });
+
+    it('should handle multiple files with different statuses', async () => {
+      const statusOutput = [
+        ' M src/modified.ts',
+        'M  src/staged.ts',
+        'A  src/added.ts',
+        '?? src/untracked.ts',
+        ' D src/deleted.ts',
+      ].join('\n') + '\n';
+
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess(statusOutput) as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/modified.ts')]).toBe('modified');
+      expect(result[testPath(repoRoot, 'src/staged.ts')]).toBe('staged');
+      expect(result[testPath(repoRoot, 'src/added.ts')]).toBe('added');
+      expect(result[testPath(repoRoot, 'src/untracked.ts')]).toBe('untracked');
+      expect(result[testPath(repoRoot, 'src/deleted.ts')]).toBe('deleted');
+    });
+
+    it('should return empty object for non-git directory', async () => {
+      mockSpawn.mockReturnValueOnce(createMockProcess('', 'fatal: not a git repository', 128) as any);
+
+      const result = await gitService.getGitStatus('/not-a-repo');
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when git command fails', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('', 'error', 1) as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result).toEqual({});
+    });
+
+    it('should prioritize worktree modifications over staged changes', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('MM src/both.ts\n') as any);
+
+      const result = await gitService.getGitStatus(repoRoot);
+
+      expect(result[testPath(repoRoot, 'src/both.ts')]).toBe('modified');
+    });
+  });
+
+  describe('getGitStatusWithIgnored', () => {
+    it('should include ignored files', async () => {
+      const repoRoot = testPath('/repo');
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess(repoRoot + '\n') as any)
+        .mockReturnValueOnce(createMockProcess('!! node_modules/\n') as any);
+
+      const result = await gitService.getGitStatusWithIgnored(repoRoot);
+
+      expect(result[testPath(repoRoot, 'node_modules/')]).toBe('ignored');
+    });
+  });
+});

--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -1,0 +1,187 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+
+export type GitFileStatus = 'modified' | 'added' | 'deleted' | 'untracked' | 'ignored' | 'staged' | 'renamed';
+export type GitStatusMap = Record<string, GitFileStatus>;
+
+class GitService {
+  /**
+   * Execute a git command and return stdout
+   */
+  private async execGit(args: string[], cwd: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('git', args, {
+        cwd,
+        shell: true,
+        windowsHide: true,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(new Error(stderr || `git exited with code ${code}`));
+        }
+      });
+
+      proc.on('error', (err) => {
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Check if a directory is inside a git repository
+   */
+  async isGitRepository(dirPath: string): Promise<boolean> {
+    try {
+      await this.execGit(['rev-parse', '--git-dir'], dirPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the root directory of the git repository
+   */
+  async getGitRoot(dirPath: string): Promise<string | null> {
+    try {
+      const result = await this.execGit(['rev-parse', '--show-toplevel'], dirPath);
+      return result.trim();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Parse git status porcelain output into a status map
+   * Format: XY PATH or XY ORIG -> PATH (for renames)
+   * X = index status, Y = worktree status
+   */
+  private parseStatusOutput(output: string, repoRoot: string): GitStatusMap {
+    const statusMap: GitStatusMap = {};
+    const lines = output.split('\n').filter(line => line.length > 0);
+
+    for (const line of lines) {
+      const indexStatus = line[0];
+      const worktreeStatus = line[1];
+      let filePath = line.substring(3);
+
+      // Handle renames: "R  old -> new"
+      if (filePath.includes(' -> ')) {
+        filePath = filePath.split(' -> ')[1];
+      }
+
+      // Convert to absolute path
+      const absolutePath = path.join(repoRoot, filePath);
+
+      // Determine the status (worktree status takes precedence for display)
+      const status = this.determineStatus(indexStatus, worktreeStatus);
+      if (status) {
+        statusMap[absolutePath] = status;
+      }
+    }
+
+    return statusMap;
+  }
+
+  /**
+   * Determine the display status from index and worktree status codes
+   */
+  private determineStatus(indexStatus: string, worktreeStatus: string): GitFileStatus | null {
+    // Untracked files
+    if (indexStatus === '?' && worktreeStatus === '?') {
+      return 'untracked';
+    }
+
+    // Ignored files
+    if (indexStatus === '!' && worktreeStatus === '!') {
+      return 'ignored';
+    }
+
+    // Worktree modifications take visual precedence (unstaged changes)
+    if (worktreeStatus === 'M') {
+      return 'modified';
+    }
+    if (worktreeStatus === 'D') {
+      return 'deleted';
+    }
+
+    // Index (staged) changes
+    if (indexStatus === 'M') {
+      return 'staged';
+    }
+    if (indexStatus === 'A') {
+      return 'added';
+    }
+    if (indexStatus === 'D') {
+      return 'deleted';
+    }
+    if (indexStatus === 'R') {
+      return 'renamed';
+    }
+
+    return null;
+  }
+
+  /**
+   * Get git status for all files in a repository
+   * Returns a map of absolute file paths to their git status
+   */
+  async getGitStatus(dirPath: string): Promise<GitStatusMap> {
+    try {
+      const repoRoot = await this.getGitRoot(dirPath);
+      if (!repoRoot) {
+        return {};
+      }
+
+      // Get status including untracked files, but not ignored
+      const output = await this.execGit(
+        ['status', '--porcelain', '-uall'],
+        repoRoot
+      );
+
+      return this.parseStatusOutput(output, repoRoot);
+    } catch (error) {
+      console.error('Error getting git status:', error);
+      return {};
+    }
+  }
+
+  /**
+   * Get git status including ignored files
+   */
+  async getGitStatusWithIgnored(dirPath: string): Promise<GitStatusMap> {
+    try {
+      const repoRoot = await this.getGitRoot(dirPath);
+      if (!repoRoot) {
+        return {};
+      }
+
+      // Get status including untracked and ignored files
+      const output = await this.execGit(
+        ['status', '--porcelain', '-uall', '--ignored'],
+        repoRoot
+      );
+
+      return this.parseStatusOutput(output, repoRoot);
+    } catch (error) {
+      console.error('Error getting git status with ignored:', error);
+      return {};
+    }
+  }
+}
+
+export const gitService = new GitService();

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -426,6 +426,44 @@ body {
   color: var(--error);
 }
 
+/* Git status colors for file tree */
+.file-tree-node.git-status-modified .file-name,
+.git-status-modified {
+  color: var(--git-modified);
+}
+
+.file-tree-node.git-status-added .file-name,
+.git-status-added {
+  color: var(--git-added);
+}
+
+.file-tree-node.git-status-deleted .file-name,
+.git-status-deleted {
+  color: var(--git-deleted);
+  text-decoration: line-through;
+}
+
+.file-tree-node.git-status-untracked .file-name,
+.git-status-untracked {
+  color: var(--git-untracked);
+}
+
+.file-tree-node.git-status-staged .file-name,
+.git-status-staged {
+  color: var(--git-staged);
+}
+
+.file-tree-node.git-status-renamed .file-name,
+.git-status-renamed {
+  color: var(--git-renamed);
+}
+
+.file-tree-node.git-status-ignored .file-name,
+.git-status-ignored {
+  color: var(--git-ignored);
+  opacity: 0.6;
+}
+
 /* Refresh button */
 .refresh-button {
   display: flex;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -30,6 +30,15 @@
   --warning: #d29922;
   --error: #f85149;
   
+  /* Git Status Colors */
+  --git-modified: #d29922;
+  --git-added: #3fb950;
+  --git-deleted: #f85149;
+  --git-untracked: #3fb950;
+  --git-staged: #3fb950;
+  --git-renamed: #3fb950;
+  --git-ignored: #6e7681;
+  
   /* ===== Typography ===== */
   --font-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', Consolas, monospace;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,3 +63,7 @@ export interface UpdateState {
   progress?: DownloadProgress;
   error?: string;
 }
+
+// Git status types
+export type GitFileStatus = 'modified' | 'added' | 'deleted' | 'untracked' | 'ignored' | 'staged' | 'renamed';
+export type GitStatusMap = Record<string, GitFileStatus>;


### PR DESCRIPTION
## Summary

Implements #22 - Adds VS Code-style git status decorations to the file tree (right pane).

## Changes

### New Files
- \src/main/services/GitService.ts\ - Git status parsing using \git status --porcelain\
- \src/main/services/GitService.test.ts\ - 15 unit tests for GitService
- \src/main/ipc/git.ts\ - IPC handlers for git operations

### Modified Files
- \src/index.ts\ - Register git IPC handlers
- \src/preload.ts\ - Expose git API to renderer
- \src/shared/types.ts\ - Add GitFileStatus and GitStatusMap types
- \src/renderer/components/RightPane/FileTree.tsx\ - Fetch & pass git status
- \src/renderer/components/RightPane/FileTreeNode.tsx\ - Render status colors with folder propagation
- \src/renderer/styles/global.css\ - Git status CSS classes
- \src/renderer/styles/variables.css\ - Git color variables
- \src/main/services/FileWatcherService.ts\ - Watch \.git/index\ for changes
- \package.json\ - Version bump 0.7.0 → 0.8.0

## Features

| Status | Color | Visual |
|--------|-------|--------|
| Modified | Yellow/Orange | Changed but not staged |
| Added/Staged/Renamed | Green | New or staged files |
| Untracked | Green | New files not yet tracked |
| Deleted | Red + strikethrough | Deleted files |
| Ignored | Dimmed gray | Files in .gitignore |

- Folders inherit the \"worst\" status of their children (like VS Code)
- Auto-refresh when git index changes
- Graceful handling of non-git directories

## Testing

- 15 new unit tests for GitService
- All 178 tests passing
- Build verification successful

Closes #22