### PR TITLE
feat: add scratch pad flyout for agent notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibe-playground",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibe-playground",
-      "version": "0.10.13",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-playground",
   "productName": "Vibe Playground",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Terminal manager with integrated file browsing for multiple repositories",
   "main": ".webpack/main",
   "private": true,

--- a/src/main/services/SessionService.test.ts
+++ b/src/main/services/SessionService.test.ts
@@ -44,7 +44,7 @@ describe('SessionService', () => {
       expect(filePath).toBe(path.join('/mock/userData', 'session.json'));
       
       const parsed = JSON.parse(content as string);
-      expect(parsed.version).toBe(3);
+      expect(parsed.version).toBe(4);
       expect(parsed.agents).toEqual(data.agents);
       expect(parsed.activeItemId).toBe('agent-1');
     });
@@ -221,13 +221,14 @@ describe('SessionService', () => {
     it('should return valid session data', () => {
       mockExistsSync.mockImplementation((p) => true);
       mockReadFileSync.mockReturnValue(JSON.stringify({
-        version: 3,
+        version: 4,
         agents: [
           { id: 'agent-1', label: 'Test', cwd: '/home', openFiles: [] },
         ],
         activeItemId: 'agent-1',
         activeAgentId: 'agent-1',
         activeConversationId: null,
+        agentNotes: {},
       }));
 
       const result = sessionService.load();
@@ -258,7 +259,7 @@ describe('SessionService', () => {
       const result = sessionService.load();
 
       expect(result).not.toBeNull();
-      expect(result?.version).toBe(3);
+      expect(result?.version).toBe(4);
       expect(result?.agents).toHaveLength(1);
       expect(result?.agents[0].id).toBe('term-1');
       expect(result?.agents[0].openFiles[0].parentAgentId).toBe('term-1');

--- a/src/main/services/SessionService.ts
+++ b/src/main/services/SessionService.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const SESSION_FILE = 'session.json';
-const SESSION_VERSION = 3;
+const SESSION_VERSION = 4;
 
 export interface SessionAgent {
   id: string;
@@ -26,6 +26,7 @@ export interface SessionData {
   activeItemId: string | null;
   activeAgentId: string | null;
   activeConversationId: string | null;
+  agentNotes?: Record<string, string>;
 }
 
 // Legacy v1 types for migration
@@ -93,6 +94,14 @@ class SessionService {
     };
   }
 
+  private migrateV3ToV4(data: SessionData & { version: 3 }): SessionData {
+    return {
+      ...data,
+      version: 4,
+      agentNotes: {},
+    };
+  }
+
   load(): SessionData | null {
     try {
       const sessionPath = this.getSessionPath();
@@ -114,6 +123,12 @@ class SessionService {
       if (data.version === 2) {
         console.log('Migrating session data from v2 to v3');
         data = this.migrateV2ToV3(data);
+      }
+
+      // Migrate v3 to v4
+      if (data.version === 3) {
+        console.log('Migrating session data from v3 to v4');
+        data = this.migrateV3ToV4(data);
       }
 
       // Validate version

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import { LeftPane } from './components/LeftPane';
 import { CenterPane } from './components/CenterPane';
 import { RightPane } from './components/RightPane';
 import { HotkeyHelp } from './components/HotkeyHelp';
+import { ScratchPad } from './components/ScratchPad';
 import { UpdateToast } from './components/UpdateToast';
 import { AppStateProvider, useAppState, getActiveItem } from './contexts/AppStateContext';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -15,6 +16,7 @@ import { AgentEvent } from '../shared/types';
 function AppContent() {
   const { state, dispatch } = useAppState();
   const [showHotkeyHelp, setShowHotkeyHelp] = useState(false);
+  const [showScratchPad, setShowScratchPad] = useState(false);
   const [renamingAgentId, setRenamingAgentId] = useState<string | null>(null);
   const { updateState, isUpdateDismissed, handleDownload: handleDownloadUpdate, handleInstall: handleInstallUpdate, handleDismiss: handleDismissUpdate } = useAutoUpdater();
 
@@ -76,6 +78,7 @@ function AppContent() {
         activeItemId: state.activeItemId,
         activeAgentId: state.activeAgentId,
         activeConversationId: state.activeConversationId,
+        agentNotes: state.agentNotes,
       });
     };
 
@@ -139,6 +142,7 @@ function AppContent() {
     { key: 'w', ctrl: true, action: handleCloseCurrentItem },
     { key: 'F2', action: handleRenameAgent },
     { key: '?', ctrl: true, shift: true, action: () => setShowHotkeyHelp(true) },
+    { key: 'j', ctrl: true, action: () => setShowScratchPad(prev => !prev) },
   ], [cycleAgent, handleCloseCurrentItem, handleRenameAgent]);
 
   useKeyboardShortcuts(shortcuts);
@@ -202,6 +206,16 @@ function AppContent() {
         />
       </div>
       <HotkeyHelp isOpen={showHotkeyHelp} onClose={() => setShowHotkeyHelp(false)} />
+      <ScratchPad
+        isOpen={showScratchPad && state.viewMode === 'agents' && !!state.activeAgentId}
+        onClose={() => setShowScratchPad(false)}
+        content={state.activeAgentId ? (state.agentNotes[state.activeAgentId] ?? '') : ''}
+        onChange={(content) => {
+          if (state.activeAgentId) {
+            dispatch({ type: 'SET_AGENT_NOTES', payload: { agentId: state.activeAgentId, content } });
+          }
+        }}
+      />
       {!isUpdateDismissed && (
         <UpdateToast
           updateState={updateState}

--- a/src/renderer/components/CenterPane/CenterPane.test.tsx
+++ b/src/renderer/components/CenterPane/CenterPane.test.tsx
@@ -57,6 +57,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<CenterPane />, state);
@@ -81,6 +82,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<CenterPane />, state);
@@ -113,6 +115,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<CenterPane />, state);
@@ -143,6 +146,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     const { container } = renderWithProvider(<CenterPane />, state);
@@ -166,6 +170,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     const { container } = renderWithProvider(<CenterPane />, state);
@@ -189,6 +194,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     const { container } = renderWithProvider(<CenterPane />, state);
@@ -213,6 +219,7 @@ describe('CenterPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<CenterPane />, state);

--- a/src/renderer/components/HotkeyHelp/HotkeyHelp.test.tsx
+++ b/src/renderer/components/HotkeyHelp/HotkeyHelp.test.tsx
@@ -71,7 +71,7 @@ describe('HotkeyHelp', () => {
     expect(table).toBeInTheDocument();
     
     const rows = table?.querySelectorAll('tr');
-    expect(rows?.length).toBe(7); // 7 shortcuts defined
+    expect(rows?.length).toBe(8); // 8 shortcuts defined
   });
 
   it('should call onClose when Escape key is pressed', () => {

--- a/src/renderer/components/HotkeyHelp/HotkeyHelp.tsx
+++ b/src/renderer/components/HotkeyHelp/HotkeyHelp.tsx
@@ -13,6 +13,7 @@ const shortcuts = [
   { keys: 'Ctrl + W', description: 'Close current agent/file' },
   { keys: 'F2', description: 'Rename agent' },
   { keys: 'Ctrl + ?', description: 'Show this help' },
+  { keys: 'Ctrl + J', description: 'Toggle scratch pad' },
   { keys: 'Ctrl + Shift + I', description: 'Open DevTools' },
 ];
 

--- a/src/renderer/components/LeftPane/LeftPane.test.tsx
+++ b/src/renderer/components/LeftPane/LeftPane.test.tsx
@@ -54,6 +54,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
     renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
     const chatItem = screen.getByText('Copilot Chat').closest('.chat-nav-item');
@@ -76,6 +77,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -99,6 +101,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -129,6 +132,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -152,6 +156,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -184,6 +189,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -210,6 +216,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={onCloseAgent} />, state);
@@ -236,6 +243,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -267,6 +275,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(
@@ -300,6 +309,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(
@@ -335,6 +345,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(
@@ -369,6 +380,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(
@@ -405,6 +417,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -429,6 +442,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -452,6 +466,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -478,6 +493,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -513,6 +529,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);
@@ -543,6 +560,7 @@ describe('LeftPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       renderWithProvider(<LeftPane onAddAgent={() => {}} onCloseAgent={() => {}} />, state);

--- a/src/renderer/components/RightPane/RightPane.test.tsx
+++ b/src/renderer/components/RightPane/RightPane.test.tsx
@@ -47,6 +47,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={() => {}} />, state);
@@ -70,6 +71,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={() => {}} />, state);
@@ -99,6 +101,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={onFileClick} />, state);
@@ -124,6 +127,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={onFileClick} />, state);
@@ -150,6 +154,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={() => {}} />, state1);
@@ -173,6 +178,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={() => {}} />, state2);
@@ -194,6 +200,7 @@ describe('RightPane', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
     };
 
     renderWithProvider(<RightPane onFileClick={() => {}} />, state);

--- a/src/renderer/components/ScratchPad/ScratchPad.tsx
+++ b/src/renderer/components/ScratchPad/ScratchPad.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
+import { Icon } from '../Icon';
+
+interface ScratchPadProps {
+  isOpen: boolean;
+  onClose: () => void;
+  content: string;
+  onChange: (content: string) => void;
+}
+
+export function ScratchPad({ isOpen, onClose, content, onChange }: ScratchPadProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isOpen && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  return (
+    <div className={`scratch-pad ${isOpen ? 'scratch-pad--open' : ''}`}>
+      <div className="scratch-pad__header">
+        <span className="scratch-pad__title">Scratch Pad</span>
+        <button className="scratch-pad__close" onClick={onClose}>
+          <Icon name="close" size="sm" />
+        </button>
+      </div>
+      <textarea
+        ref={textareaRef}
+        className="scratch-pad__textarea"
+        value={content}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Jot down notes for this agent..."
+        spellCheck={false}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/ScratchPad/index.ts
+++ b/src/renderer/components/ScratchPad/index.ts
@@ -1,0 +1,1 @@
+export { ScratchPad } from './ScratchPad';

--- a/src/renderer/contexts/AppStateContext.test.tsx
+++ b/src/renderer/contexts/AppStateContext.test.tsx
@@ -321,6 +321,7 @@ describe('selectors', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       const result = getActiveAgent(state);
@@ -346,6 +347,7 @@ describe('selectors', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       const result = getActiveItem(state);
@@ -373,6 +375,7 @@ describe('selectors', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       const result = getActiveItem(state);
@@ -406,6 +409,7 @@ describe('selectors', () => {
       availableModels: [],
       selectedModel: null,
       agentEvents: {},
+      agentNotes: {},
       };
 
       const result = getFilesForAgent(state, 'agent-1');

--- a/src/renderer/contexts/AppStateContext.tsx
+++ b/src/renderer/contexts/AppStateContext.tsx
@@ -16,6 +16,7 @@ export const initialState: AppState = {
   availableModels: [],
   selectedModel: null,
   agentEvents: {},
+  agentNotes: {},
 };
 
 export function appReducer(state: AppState, action: AppAction): AppState {
@@ -32,6 +33,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'SET_AGENT_HAS_SESSION':
     case 'ADD_AGENT_EVENT':
     case 'CLEAR_AGENT_EVENTS':
+    case 'SET_AGENT_NOTES':
       return agentReducer(state, action);
 
     case 'ADD_CHAT_MESSAGE':

--- a/src/renderer/contexts/agentReducer.ts
+++ b/src/renderer/contexts/agentReducer.ts
@@ -13,6 +13,7 @@ type AgentAction = Extract<AppAction,
   | { type: 'SET_AGENT_HAS_SESSION' }
   | { type: 'ADD_AGENT_EVENT' }
   | { type: 'CLEAR_AGENT_EVENTS' }
+  | { type: 'SET_AGENT_NOTES' }
 >;
 
 export function agentReducer(state: AppState, action: AgentAction): AppState {
@@ -43,6 +44,7 @@ export function agentReducer(state: AppState, action: AgentAction): AppState {
         : state.activeAgentId;
       const newActiveItemId = wasActive ? newActiveAgentId : state.activeItemId;
       const { [action.payload.id]: _, ...remainingEvents } = state.agentEvents;
+      const { [action.payload.id]: __, ...remainingNotes } = state.agentNotes;
 
       return {
         ...state,
@@ -50,6 +52,7 @@ export function agentReducer(state: AppState, action: AgentAction): AppState {
         activeItemId: newActiveItemId,
         activeAgentId: newActiveAgentId,
         agentEvents: remainingEvents,
+        agentNotes: remainingNotes,
       };
     }
 
@@ -139,6 +142,15 @@ export function agentReducer(state: AppState, action: AgentAction): AppState {
         agentEvents: {
           ...state.agentEvents,
           [action.payload.agentId]: [],
+        },
+      };
+
+    case 'SET_AGENT_NOTES':
+      return {
+        ...state,
+        agentNotes: {
+          ...state.agentNotes,
+          [action.payload.agentId]: action.payload.content,
         },
       };
 

--- a/src/renderer/hooks/useSessionRestore.ts
+++ b/src/renderer/hooks/useSessionRestore.ts
@@ -61,6 +61,15 @@ export function useSessionRestore(dispatch: React.Dispatch<AppAction>): void {
               },
             });
           }
+
+          // Restore agent notes
+          if (sessionData.agentNotes) {
+            for (const [agentId, content] of Object.entries(sessionData.agentNotes)) {
+              if (content && sessionData.agents.some(a => a.id === agentId)) {
+                dispatch({ type: 'SET_AGENT_NOTES', payload: { agentId, content } });
+              }
+            }
+          }
         }
 
         // Restore active conversation and its messages

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1174,3 +1174,77 @@ kbd {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
+
+/* ===== Scratch Pad Flyout ===== */
+
+.scratch-pad {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 250px;
+  background-color: var(--bg-surface);
+  border-top: 1px solid var(--border-subtle);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 500;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform var(--transition-slow);
+}
+
+.scratch-pad--open {
+  transform: translateY(0);
+}
+
+.scratch-pad__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-muted);
+  flex-shrink: 0;
+}
+
+.scratch-pad__title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.scratch-pad__close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.scratch-pad__close:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.scratch-pad__textarea {
+  flex: 1;
+  background-color: var(--bg-deep);
+  color: var(--text-primary);
+  border: none;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  resize: none;
+  outline: none;
+}
+
+.scratch-pad__textarea::placeholder {
+  color: var(--text-muted);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -171,6 +171,7 @@ export interface AppState {
   availableModels: ModelInfo[];
   selectedModel: string | null;
   agentEvents: Record<string, AgentEvent[]>;
+  agentNotes: Record<string, string>;
 }
 
 export interface SessionData {
@@ -179,6 +180,7 @@ export interface SessionData {
   activeItemId: string | null;
   activeAgentId: string | null;
   activeConversationId: string | null;
+  agentNotes?: Record<string, string>;
 }
 
 export type AppAction =
@@ -204,7 +206,8 @@ export type AppAction =
   | { type: 'ADD_AGENT_EVENT'; payload: { agentId: string; event: AgentEvent } }
   | { type: 'SET_AGENT_STATUS'; payload: { agentId: string; status: AgentStatus } }
   | { type: 'CLEAR_AGENT_EVENTS'; payload: { agentId: string } }
-  | { type: 'SET_AGENT_HAS_SESSION'; payload: { agentId: string; hasSession: boolean } };
+  | { type: 'SET_AGENT_HAS_SESSION'; payload: { agentId: string; hasSession: boolean } }
+  | { type: 'SET_AGENT_NOTES'; payload: { agentId: string; content: string } };
 
 // Auto-update types
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'ready' | 'error' | 'dev-mode';


### PR DESCRIPTION
## Summary

Closes #23. Adds a scratch pad flyout panel that slides up from the bottom of the screen, allowing users to jot down notes per agent.

## Changes

### State Layer
- Added `agentNotes: Record<string, string>` to `AppState`
- Added `SET_AGENT_NOTES` action with reducer handling
- Notes cleaned up automatically on agent removal

### Persistence
- Bumped SessionService to v4 with v3→v4 migration
- Notes saved on app close (`beforeunload`) and restored on launch

### UI Component
- New `ScratchPad` component: 250px bottom flyout with slide-up animation
- Auto-focuses textarea on open
- Esc key closes the panel

### Integration
- `Ctrl+J` toggles the scratch pad (added to HotkeyHelp modal)
- Notes are agent-specific — switching agents shows that agent's notes
- Hidden in chat mode and when no agent is active

### Version
- Bumped to `0.11.0`

## Testing
- All 338 tests passing across 31 suites
- Updated all test fixtures with `agentNotes: {}`
- Updated SessionService tests for v4 version
- Updated HotkeyHelp test for new shortcut count