### PR TITLE
fix: add lang="en" to html tag in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>cmux</title>


### PR DESCRIPTION
Add `lang="en"` attribute to the `<html>` element in `src/index.html` for accessibility and screen reader language detection.

**Changes:**
- Added `lang="en"` to the root `<html>` element

Fixes #53