### PR TITLE
feat: adopt structured logging with electron-log

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '/Logger$': '<rootDir>/src/test/__mocks__/Logger',
   },
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
+        "electron-log": "^5.4.3",
         "electron-squirrel-startup": "^1.0.1",
         "electron-updater": "^6.7.3",
         "monaco-editor": "^0.55.1",
@@ -7091,6 +7092,15 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-rebuild": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.1",
     "electron-updater": "^6.7.3",
     "monaco-editor": "^0.55.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,9 @@ import { setupConversationIPC } from './main/ipc/conversation';
 import { setupAgentSessionIPC } from './main/ipc/agent-session';
 import { stopSharedClient } from './main/services/SdkLoader';
 import { agentSessionService } from './main/services/AgentSessionService';
+import { createLogger } from './main/services/Logger';
+
+const log = createLogger('Main');
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
@@ -20,7 +23,7 @@ if (isSquirrelUninstall && process.platform === 'win32' && app.isPackaged) {
     const userDataDir = app.getPath('userData');
     fs.rmSync(userDataDir, { recursive: true, force: true });
   } catch (error) {
-    console.error('[UninstallCleanup] Failed to remove user data directory:', error);
+    log.error('Failed to remove user data directory:', error);
   }
 }
 

--- a/src/main/ipc/copilot.ts
+++ b/src/main/ipc/copilot.ts
@@ -1,6 +1,9 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { CopilotService } from '../services/CopilotService';
 import { createOrchestratorTools, setOnAgentCreated, getActiveAgents, registerAgent, ORCHESTRATOR_SYSTEM_MESSAGE } from '../services/OrchestratorTools';
+import { createLogger } from '../services/Logger';
+
+const log = createLogger('IPC:Copilot');
 
 const copilotService = new CopilotService();
 let toolsInitialized = false;
@@ -20,7 +23,7 @@ async function ensureToolsInitialized(mainWindow: BrowserWindow): Promise<void> 
       mainWindow.webContents.send('orchestrator:agent-created', info);
     });
   } catch (err) {
-    console.error('Failed to initialize orchestrator tools:', err);
+    log.error('Failed to initialize orchestrator tools:', err);
     toolsInitialized = false;
   }
 }

--- a/src/main/services/CopilotBootstrap.ts
+++ b/src/main/services/CopilotBootstrap.ts
@@ -3,6 +3,9 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getBundledNodeRoot, getCopilotBootstrapDir, getCopilotLocalNodeModulesDir } from './AppPaths';
+import { createLogger } from './Logger';
+
+const log = createLogger('CopilotBootstrap');
 let bootstrapPromise: Promise<void> | null = null;
 const isWindows = process.platform === 'win32';
 
@@ -86,10 +89,10 @@ async function runNpmInstall(): Promise<void> {
     });
 
     child.stdout.on('data', (data) => {
-      console.log(`[CopilotBootstrap] ${data.toString().trim()}`);
+      log.info(data.toString().trim());
     });
     child.stderr.on('data', (data) => {
-      console.warn(`[CopilotBootstrap] ${data.toString().trim()}`);
+      log.warn(data.toString().trim());
     });
 
     child.on('error', (error) => reject(error));
@@ -135,7 +138,7 @@ export async function ensureCopilotInstalled(): Promise<void> {
   }
 
   bootstrapPromise = (async () => {
-    console.log('[CopilotBootstrap] Installing GitHub Copilot runtime...');
+    log.info('Installing GitHub Copilot runtime...');
     await runNpmInstall();
     if (!isLocalCopilotInstallReady()) {
       throw new Error('Copilot runtime installation did not complete.');
@@ -146,7 +149,7 @@ export async function ensureCopilotInstalled(): Promise<void> {
   try {
     await bootstrapPromise;
   } catch (error) {
-    console.error('[CopilotBootstrap] Install failed:', error);
+    log.error('Install failed:', error);
     throw error;
   } finally {
     bootstrapPromise = null;

--- a/src/main/services/FileService.ts
+++ b/src/main/services/FileService.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { FileEntry } from '../../shared/types';
+import { createLogger } from './Logger';
+
+const log = createLogger('FileService');
 
 export type { FileEntry };
 
@@ -24,7 +27,7 @@ class FileService {
 
   async readDirectory(dirPath: string, options?: { showHidden?: boolean }): Promise<FileEntry[]> {
     if (!this.isPathAllowed(dirPath)) {
-      console.error('Access denied: path outside allowed roots:', dirPath);
+      log.error('Access denied: path outside allowed roots:', dirPath);
       return [];
     }
 
@@ -47,7 +50,7 @@ class FileService {
 
       return fileEntries;
     } catch (error) {
-      console.error('Error reading directory:', error);
+      log.error('Error reading directory:', error);
       return [];
     }
   }
@@ -61,7 +64,7 @@ class FileService {
       const content = await fs.promises.readFile(filePath, 'utf-8');
       return content;
     } catch (error) {
-      console.error('Error reading file:', error);
+      log.error('Error reading file:', error);
       throw error;
     }
   }

--- a/src/main/services/FileWatcherService.ts
+++ b/src/main/services/FileWatcherService.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { BrowserWindow } from 'electron';
 import type { FileWatchEvent, GitStatusChangeEvent } from '../../shared/types';
+import { createLogger } from './Logger';
+
+const log = createLogger('FileWatcherService');
 
 export type { FileWatchEvent };
 export type { GitStatusChangeEvent };
@@ -34,14 +37,14 @@ class FileWatcherService {
       });
 
       watcher.on('error', (err) => {
-        console.error(`Watcher error for ${normalizedPath}:`, err);
+        log.error(`Watcher error for ${normalizedPath}:`, err);
         this.unwatchDirectory(normalizedPath);
       });
 
       this.watchers.set(normalizedPath, watcher);
       return true;
     } catch (err) {
-      console.error(`Failed to watch directory ${dirPath}:`, err);
+      log.error(`Failed to watch directory ${dirPath}:`, err);
       return false;
     }
   }
@@ -132,14 +135,14 @@ class FileWatcherService {
       });
 
       watcher.on('error', (err) => {
-        console.error(`Git watcher error for ${repoRoot}:`, err);
+        log.error(`Git watcher error for ${repoRoot}:`, err);
         this.unwatchGitRepo(repoRoot);
       });
 
       this.gitWatchers.set(repoRoot, watcher);
       return true;
     } catch (err) {
-      console.error(`Failed to watch git repo ${repoRoot}:`, err);
+      log.error(`Failed to watch git repo ${repoRoot}:`, err);
       return false;
     }
   }
@@ -198,7 +201,7 @@ class FileWatcherService {
         try {
           callback(event);
         } catch (err) {
-          console.error('Error in git status callback:', err);
+          log.error('Error in git status callback:', err);
         }
       }
     }, this.GIT_DEBOUNCE_MS);
@@ -228,7 +231,7 @@ class FileWatcherService {
         try {
           callback(event);
         } catch (err) {
-          console.error('Error in file watcher callback:', err);
+          log.error('Error in file watcher callback:', err);
         }
       }
     }, this.DEBOUNCE_MS);

--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -1,6 +1,9 @@
 import { spawn } from 'child_process';
 import * as path from 'path';
 import type { GitFileStatus, GitStatusMap } from '../../shared/types';
+import { createLogger } from './Logger';
+
+const log = createLogger('GitService');
 
 export type { GitFileStatus, GitStatusMap };
 
@@ -154,7 +157,7 @@ class GitService {
 
       return this.parseStatusOutput(output, repoRoot);
     } catch (error) {
-      console.error('Error getting git status:', error);
+      log.error('Error getting git status:', error);
       return {};
     }
   }

--- a/src/main/services/Logger.ts
+++ b/src/main/services/Logger.ts
@@ -1,0 +1,13 @@
+import log from 'electron-log/main';
+
+// Configure log levels and output
+log.transports.file.level = 'info';
+log.transports.console.level = 'debug';
+log.transports.file.maxSize = 5 * 1024 * 1024; // 5MB rotation
+
+// Scope-based logger factory
+export function createLogger(scope: string) {
+  return log.scope(scope);
+}
+
+export default log;

--- a/src/main/services/SdkLoader.ts
+++ b/src/main/services/SdkLoader.ts
@@ -15,6 +15,9 @@ import {
   getLocalCopilotNodeModulesDir,
   isLocalCopilotInstallReady,
 } from './CopilotBootstrap';
+import { createLogger } from './Logger';
+
+const log = createLogger('SdkLoader');
 
 type CopilotClientType = import('@github/copilot-sdk').CopilotClient;
 
@@ -255,7 +258,7 @@ async function getCopilotNodeModules(): Promise<string> {
   }
 
   if (bootstrapError) {
-    console.warn('[SdkLoader] Copilot bootstrap failed, falling back to global install:', bootstrapError);
+    log.warn('Copilot bootstrap failed, falling back to global install:', bootstrapError);
   }
 
   return getGlobalNodeModules();

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -2,6 +2,9 @@ import './renderer/styles/global.css';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './renderer/App';
+import { createLogger } from './renderer/logger';
+
+const log = createLogger('Renderer');
 
 // Suppress benign ResizeObserver error from Monaco Editor
 const resizeObserverErr = window.onerror;
@@ -19,11 +22,11 @@ window.addEventListener('error', (e) => {
   }
 });
 
-console.log('Renderer script loading...');
+log.info('Renderer script loading...');
 
 const container = document.getElementById('root');
 if (container) {
-  console.log('Root container found, mounting React app...');
+  log.info('Root container found, mounting React app...');
   try {
     const root = createRoot(container);
     root.render(
@@ -31,12 +34,12 @@ if (container) {
         <App />
       </React.StrictMode>
     );
-    console.log('React app mounted successfully');
+    log.info('React app mounted successfully');
   } catch (error) {
-    console.error('Failed to mount React app:', error);
+    log.error('Failed to mount React app:', error);
     container.innerHTML = `<pre style="color: red; padding: 20px;">Error: ${error}</pre>`;
   }
 } else {
-  console.error('Root container not found!');
+  log.error('Root container not found!');
   document.body.innerHTML = '<pre style="color: red; padding: 20px;">Root container not found!</pre>';
 }

--- a/src/renderer/components/CenterPane/AgentView.tsx
+++ b/src/renderer/components/CenterPane/AgentView.tsx
@@ -3,6 +3,9 @@ import { useEffect, useRef, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
+import { createLogger } from '../../logger';
+
+const log = createLogger('AgentView');
 
 interface AgentViewProps {
   agentId: string;
@@ -125,7 +128,7 @@ export function AgentView({ agentId, cwd, isActive }: AgentViewProps) {
     // Handle terminal exit
     const cleanupOnExit = window.electronAPI.agent.onExit((id, exitCode) => {
       if (id === agentId) {
-        console.log(`Agent ${agentId} exited with code ${exitCode}`);
+        log.info(`Agent ${agentId} exited with code ${exitCode}`);
       }
     });
 

--- a/src/renderer/components/CenterPane/FileView.tsx
+++ b/src/renderer/components/CenterPane/FileView.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { createLogger } from '../../logger';
+
+const log = createLogger('FileView');
 
 interface FileViewProps {
   filePath: string;
@@ -60,7 +63,7 @@ export const FileView: React.FC<FileViewProps> = ({ filePath, fileName }) => {
         setContent(fileContent);
       } catch (err) {
         setError(`Failed to load file: ${err}`);
-        console.error('Error loading file:', err);
+        log.error('Error loading file:', err);
       } finally {
         setLoading(false);
       }

--- a/src/renderer/hooks/useDirectoryLoader.ts
+++ b/src/renderer/hooks/useDirectoryLoader.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { FileEntry } from '../../shared/types';
+import { createLogger } from '../logger';
+
+const log = createLogger('useDirectoryLoader');
 
 export interface UseDirectoryLoaderResult {
   rootEntries: FileEntry[];
@@ -29,7 +32,7 @@ export function useDirectoryLoader(rootPath: string, refreshTrigger: number, sho
       childrenCacheRef.current.set(dirPath, entries);
       return entries;
     } catch (err) {
-      console.error('Error loading directory:', err);
+      log.error('Error loading directory:', err);
       return [];
     }
   }, [showHidden]);
@@ -52,7 +55,7 @@ export function useDirectoryLoader(rootPath: string, refreshTrigger: number, sho
         setRootEntries(entries);
       } catch (err) {
         setError('Failed to load directory');
-        console.error('Error loading directory:', err);
+        log.error('Error loading directory:', err);
       } finally {
         setLoading(false);
       }

--- a/src/renderer/hooks/useGitStatusWatcher.ts
+++ b/src/renderer/hooks/useGitStatusWatcher.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { GitStatusMap } from '../../shared/types';
+import { createLogger } from '../logger';
+
+const log = createLogger('useGitStatusWatcher');
 
 export interface UseGitStatusWatcherResult {
   gitStatusMap: GitStatusMap;
@@ -22,7 +25,7 @@ export function useGitStatusWatcher(rootPath: string): UseGitStatusWatcherResult
         setGitStatusMap({});
       }
     } catch (err) {
-      console.error('Error loading git status:', err);
+      log.error('Error loading git status:', err);
       setGitStatusMap({});
     }
   }, [rootPath]);

--- a/src/renderer/hooks/useSessionRestore.test.ts
+++ b/src/renderer/hooks/useSessionRestore.test.ts
@@ -205,7 +205,7 @@ describe('useSessionRestore', () => {
     renderHook(() => useSessionRestore(dispatch));
     await new Promise(r => setTimeout(r, 50));
 
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to restore session:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('[useSessionRestore]', 'Failed to restore session:', expect.any(Error));
     consoleSpy.mockRestore();
   });
 

--- a/src/renderer/hooks/useSessionRestore.ts
+++ b/src/renderer/hooks/useSessionRestore.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { AppAction } from '../../shared/types';
+import { createLogger } from '../logger';
+
+const log = createLogger('useSessionRestore');
 
 export function useSessionRestore(dispatch: React.Dispatch<AppAction>): void {
   const hasRestoredRef = useRef(false);
@@ -93,7 +96,7 @@ export function useSessionRestore(dispatch: React.Dispatch<AppAction>): void {
           }
         }
       } catch (error) {
-        console.error('Failed to restore session:', error);
+        log.error('Failed to restore session:', error);
       }
     };
 

--- a/src/renderer/logger.ts
+++ b/src/renderer/logger.ts
@@ -1,0 +1,12 @@
+// Renderer-side logging utility
+// In Electron renderer, we use console with structured prefixes
+// electron-log's renderer transport can be configured if needed
+
+export function createLogger(scope: string) {
+  return {
+    info: (...args: unknown[]) => console.log(`[${scope}]`, ...args),
+    warn: (...args: unknown[]) => console.warn(`[${scope}]`, ...args),
+    error: (...args: unknown[]) => console.error(`[${scope}]`, ...args),
+    debug: (...args: unknown[]) => console.debug(`[${scope}]`, ...args),
+  };
+}

--- a/src/test/__mocks__/Logger.ts
+++ b/src/test/__mocks__/Logger.ts
@@ -1,0 +1,13 @@
+// Mock Logger for tests — avoids importing electron-log which requires Electron runtime
+const noopLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+export function createLogger() {
+  return noopLogger;
+}
+
+export default noopLogger;


### PR DESCRIPTION
Replace `console.log/warn/error` with `electron-log` across the codebase. Main process files use electron-log with scoped loggers for structured output with log levels, file rotation, and timestamps. Renderer files use a lightweight scoped logger wrapper.

**Changes:**
- Added `electron-log` dependency
- Created `src/main/services/Logger.ts` (main process logger)
- Created `src/renderer/logger.ts` (renderer logger)
- Migrated ~51 console.* calls across ~20 files to scoped loggers

Fixes #50