### PR TITLE
feat: add copy path context menu option to file tree

### DIFF
--- a/src/renderer/components/Icon.tsx
+++ b/src/renderer/components/Icon.tsx
@@ -46,7 +46,8 @@ export type IconName =
   | 'error'
   | 'person'
   | 'eye'
-  | 'eye-closed';
+  | 'eye-closed'
+  | 'copy';
 
 interface IconProps {
   name: IconName;

--- a/src/renderer/components/RightPane/FileTreeNode.tsx
+++ b/src/renderer/components/RightPane/FileTreeNode.tsx
@@ -18,6 +18,7 @@ interface FileTreeNodeProps {
   level: number;
   onFileClick: (path: string) => void;
   onDirectoryToggle: (path: string, isExpanded: boolean) => void;
+  onContextMenu?: (e: React.MouseEvent, path: string) => void;
   expandedDirs: Set<string>;
   loadChildren: (path: string) => Promise<FileEntry[]>;
   getChildren: (path: string) => FileEntry[];
@@ -29,6 +30,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   level,
   onFileClick,
   onDirectoryToggle,
+  onContextMenu,
   expandedDirs,
   loadChildren,
   getChildren,
@@ -91,6 +93,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
         className={`file-tree-node ${statusClass}`}
         style={{ paddingLeft: `${indent}px` }}
         onClick={handleClick}
+        onContextMenu={onContextMenu ? (e) => onContextMenu(e, entry.path) : undefined}
         tabIndex={0}
         onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       >
@@ -118,6 +121,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
               level={level + 1}
               onFileClick={onFileClick}
               onDirectoryToggle={onDirectoryToggle}
+              onContextMenu={onContextMenu}
               expandedDirs={expandedDirs}
               loadChildren={loadChildren}
               getChildren={getChildren}


### PR DESCRIPTION
Closes #46

Adds a right-click context menu to the file tree with a **Copy Path** option. Works for both files and folders.

### Changes
- **FileTreeNode**: Added optional `onContextMenu` prop that fires on right-click, passing the node's path upward
- **FileTree**: Integrated `useContextMenu` hook to manage context menu state, renders a context menu overlay with a Copy Path button that writes the path to the clipboard via `navigator.clipboard.writeText()`  
- **Icon**: Added `copy` to the `IconName` union (uses VS Code codicon `codicon-copy`)
- **Tests**: Added 2 new tests covering right-click copy path for files and folders

All 33 existing tests continue to pass.